### PR TITLE
fix: gracefully handling new sprite name conflicts

### DIFF
--- a/packages/mini_sprite_editor/lib/library/cubit/library_cubit.dart
+++ b/packages/mini_sprite_editor/lib/library/cubit/library_cubit.dart
@@ -55,12 +55,24 @@ class LibraryCubit extends Cubit<LibraryState> {
     );
   }
 
+  String _newSpriteKey() {
+    var _idx = state.sprites.length + 1;
+    var _spriteKey = 'sprite_$_idx';
+
+    while (state.sprites.containsKey(_spriteKey)) {
+      _idx++;
+      _spriteKey = 'sprite_$_idx';
+    }
+
+    return _spriteKey;
+  }
+
   void addSprite(int width, int height) {
     emit(
       state.copyWith(
         sprites: {
           ...state.sprites,
-          'sprite_${state.sprites.length + 1}': MiniSprite(
+          _newSpriteKey(): MiniSprite(
             List.generate(
               height,
               (_) => List.generate(

--- a/packages/mini_sprite_editor/test/library/cubit/library_cubit_test.dart
+++ b/packages/mini_sprite_editor/test/library/cubit/library_cubit_test.dart
@@ -250,6 +250,42 @@ void main() {
     );
 
     blocTest<LibraryCubit, LibraryState>(
+      'can handle name conflict on addSprite',
+      seed: () => const LibraryState(
+        sprites: {
+          'sprite_2': MiniSprite(
+            [
+              [false, false],
+              [false, false],
+            ],
+          ),
+        },
+        selected: '',
+      ),
+      build: LibraryCubit.new,
+      act: (cubit) => cubit.addSprite(2, 2),
+      expect: () => [
+        LibraryState(
+          sprites: const {
+            'sprite_2': MiniSprite(
+              [
+                [false, false],
+                [false, false],
+              ],
+            ),
+            'sprite_3': MiniSprite(
+              [
+                [false, false],
+                [false, false],
+              ],
+            ),
+          },
+          selected: '',
+        ),
+      ],
+    );
+
+    blocTest<LibraryCubit, LibraryState>(
       'selects a sprite',
       seed: () => LibraryState(
         sprites: {'player': MiniSprite.empty(1, 1)},


### PR DESCRIPTION
## Description

Fixes the name conflict on the new sprite feature.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
