### PR TITLE
fix: Choose correct text for sprite remove key

### DIFF
--- a/packages/mini_sprite_editor/lib/library/view/library_panel.dart
+++ b/packages/mini_sprite_editor/lib/library/view/library_panel.dart
@@ -78,7 +78,7 @@ class _LibraryPanelState extends State<LibraryPanel> {
                   ),
                   IconButton(
                     key: const Key('remove_sprite_key'),
-                    tooltip: l10n.renameSprite,
+                    tooltip: l10n.removeSprite,
                     onPressed: () async {
                       final cubit = context.read<LibraryCubit>();
                       final value = await ConfirmDialog.show(context);


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Just fixes the text that said rename before, but should say remove.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
