### PR TITLE
feat: Adding copy colors feature

### DIFF
--- a/packages/mini_sprite_editor/lib/config/cubit/config_cubit.dart
+++ b/packages/mini_sprite_editor/lib/config/cubit/config_cubit.dart
@@ -1,11 +1,19 @@
+import 'dart:async';
+
 import 'package:equatable/equatable.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:hydrated_bloc/hydrated_bloc.dart';
 
 part 'config_state.dart';
 
 class ConfigCubit extends HydratedCubit<ConfigState> {
-  ConfigCubit() : super(const ConfigState.initial());
+  ConfigCubit({
+    Future<void> Function(ClipboardData)? setClipboardData,
+  }) : _setClipboardData = setClipboardData ?? Clipboard.setData,
+       super(const ConfigState.initial());
+
+  final Future<void> Function(ClipboardData) _setClipboardData;
 
   void setThemeMode(ThemeMode mode) {
     emit(state.copyWith(themeMode: mode));
@@ -37,6 +45,13 @@ class ConfigCubit extends HydratedCubit<ConfigState> {
 
   void setGridSize(int value) {
     emit(state.copyWith(mapGridSize: value));
+  }
+
+  void copyPaletteToClipboard() {
+    final colorsInHex = state.colors
+        .map((e) => e.toARGB32().toRadixString(16).padLeft(8, '0'))
+        .join('\n');
+    unawaited(_setClipboardData(ClipboardData(text: colorsInHex)));
   }
 
   @override

--- a/packages/mini_sprite_editor/lib/sprite/view/sprite_page.dart
+++ b/packages/mini_sprite_editor/lib/sprite/view/sprite_page.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:flame/image_composition.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:mini_sprite_editor/config/config.dart';

--- a/packages/mini_sprite_editor/lib/sprite/view/sprite_page.dart
+++ b/packages/mini_sprite_editor/lib/sprite/view/sprite_page.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flame/image_composition.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:mini_sprite_editor/config/config.dart';
@@ -7,6 +8,7 @@ import 'package:mini_sprite_editor/l10n/l10n.dart';
 import 'package:mini_sprite_editor/library/library.dart';
 import 'package:mini_sprite_editor/sprite/cubit/tools_cubit.dart';
 import 'package:mini_sprite_editor/sprite/sprite.dart';
+import 'package:mini_sprite_editor/widgets/composed_icon.dart';
 
 class SpritePage extends StatelessWidget {
   const SpritePage({super.key});
@@ -219,6 +221,22 @@ class SpriteView extends StatelessWidget {
                     },
                     tooltip: l10n.copyToClipboard,
                     icon: const Icon(Icons.download),
+                  ),
+                  Tooltip(
+                    message: l10n.copyToClipboard,
+                    child: GestureDetector(
+                      key: const Key('copy_palette_clipboard_key'),
+                      onTap: () {
+                        context.read<ConfigCubit>().copyPaletteToClipboard();
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          SnackBar(content: Text(l10n.copiedWithSuccess)),
+                        );
+                      },
+                      child: const ComposedIcon(
+                        primary: Icons.palette,
+                        secondary: Icons.download,
+                      ),
+                    ),
                   ),
                   IconButton(
                     key: const Key('import_from_clipboard_key'),

--- a/packages/mini_sprite_editor/lib/widgets/composed_icon.dart
+++ b/packages/mini_sprite_editor/lib/widgets/composed_icon.dart
@@ -1,0 +1,41 @@
+import 'package:flame/extensions.dart';
+import 'package:flutter/material.dart';
+
+class ComposedIcon extends StatelessWidget {
+  const ComposedIcon({
+    required this.primary,
+    required this.secondary,
+    super.key,
+  });
+
+  final IconData primary;
+  final IconData secondary;
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      clipBehavior: Clip.none,
+      children: [
+        Icon(primary),
+        Positioned(
+          left: 10,
+          top: 6,
+          child: Icon(
+            size: 18,
+            shadows: [
+              Shadow(
+                color:
+                    Theme.of(context).iconTheme.color?.darken(
+                      .7,
+                    ) ??
+                    Colors.black,
+                blurRadius: 4,
+              ),
+            ],
+            secondary,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/packages/mini_sprite_editor/lib/widgets/widgets.dart
+++ b/packages/mini_sprite_editor/lib/widgets/widgets.dart
@@ -1,0 +1,1 @@
+export 'composed_icon.dart';


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Adds a new feature that allows devs to copy the current color palette. It uses the `.hex` format, where each color is placed in a line (in the video they all get in a single line because I pasted it on the browser url field, which doesn't support multline)

https://github.com/user-attachments/assets/96630248-0d80-4cf1-8dc3-14f0980eb2f9



## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
